### PR TITLE
Create renovate-default.json

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        "helpers:pinGitHubActionDigestsToSemver"
+    ],
+    "dependencyDashboardApproval": true,
+    "semanticCommits": "disabled"
+}


### PR DESCRIPTION
I added the renovate-default.json which sets the option for ALL Module-Repositories.
The each module-repository will be created get also the proper renovate config to use this default one.

closes https://github.com/cloudeteer/tf-mod-lib/issues/377