### PR TITLE
Create GitHub issue on failed scheduled run

### DIFF
--- a/.github/workflows/module-ci-issue.yaml
+++ b/.github/workflows/module-ci-issue.yaml
@@ -1,0 +1,21 @@
+name: module-ci-issue
+on: workflow_call
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create GitHub Issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runLink = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const issueTitle = `Scheduled workflow \`${context.github.workflow}\` failed``;
+            const issueBody = `See [Action run](${runLink}) for details.`;
+            const response = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: issueTitle,
+              body: issueBody
+            });

--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -32,6 +32,11 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
   release:
-    if: github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     needs: [validate, lint, documentation, code-analysis, test]
     uses: ./.github/workflows/module-ci-release.yaml
+
+  issue:
+    if: github.event_name == 'schedule' && failure()
+    needs: [validate, lint, documentation, code-analysis, test]
+    uses: ./.github/workflows/module-ci-issue.yaml

--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -8,10 +8,6 @@ on:
       ARM_TENANT_ID:
 
 jobs:
-  pull-request:
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/module-ci-pull-request.yaml
-
   validate:
     uses: ./.github/workflows/module-ci-validate.yaml
 
@@ -30,6 +26,10 @@ jobs:
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+
+  pull-request:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/module-ci-pull-request.yaml
 
   release:
     if: github.event_name == 'push' && github.ref_name == 'main'


### PR DESCRIPTION
This PR introduces a new workflow that triggers only when `github.event_name = "schedule"`. The purpose of this workflow is to automatically create a GitHub issue if any of the workflows it depends on (`needs: ...`) have failed.