### PR TITLE
Skips dirs on Trivy scan

### DIFF
--- a/.github/workflows/module-ci-code-analysis.yaml
+++ b/.github/workflows/module-ci-code-analysis.yaml
@@ -16,3 +16,4 @@ jobs:
           scan-type: fs
           scanners: config,secret
           severity: CRITICAL,HIGH
+          skip-dirs: examples/,tests/


### PR DESCRIPTION
Skip `examples/` and `test/` directories on Trivy scan
