### PR TITLE
Use required Terraform version on remote test

### DIFF
--- a/.github/workflows/module-ci-lint.yaml
+++ b/.github/workflows/module-ci-lint.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - name: Get terraform version
         id: terraform_version
-        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        uses: cloudeteer/actions/get-terraform-version@main
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/module-ci-lint.yaml
+++ b/.github/workflows/module-ci-lint.yaml
@@ -10,8 +10,6 @@ jobs:
       - name: Get terraform version
         id: terraform_version
         uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
-        with:
-          file-path: versions.tf
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/module-ci-lint.yaml
+++ b/.github/workflows/module-ci-lint.yaml
@@ -3,13 +3,22 @@ on: workflow_call
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:1.9
     steps:
       - uses: actions/checkout@v4
         name: Checkout source code
 
-      - name: Checkout terraform-docs.yaml
+      - name: Get terraform version
+        id: terraform_version
+        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        with:
+          file-path: versions.tf
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.terraform_version.outputs.required_version }}
+
+      - name: Checkout tflint.hcl
         uses: actions/checkout@v4
         with:
           path: .terraform-governance
@@ -18,6 +27,7 @@ jobs:
           sparse-checkout: |
             tflint.hcl
             tflint.examples.hcl
+            tflint.tests.hcl
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v4

--- a/.github/workflows/module-ci-test.yaml
+++ b/.github/workflows/module-ci-test.yaml
@@ -38,6 +38,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get terraform version
+        id: terraform_version
+        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        with:
+          file-path: tests/remote/terraform.tf
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.terraform_version.outputs.required_version }}
+
       - name: az login
         uses: azure/login@v2
         with:

--- a/.github/workflows/module-ci-test.yaml
+++ b/.github/workflows/module-ci-test.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get terraform version
         id: terraform_version
-        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        uses: cloudeteer/actions/get-terraform-version@main
         with:
           directory: tests/remote
 

--- a/.github/workflows/module-ci-test.yaml
+++ b/.github/workflows/module-ci-test.yaml
@@ -42,7 +42,7 @@ jobs:
         id: terraform_version
         uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
         with:
-          file-path: tests/remote/terraform.tf
+          directory: tests/remote
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/module-ci-validate.yaml
+++ b/.github/workflows/module-ci-validate.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - name: Get terraform version
         id: terraform_version
-        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        uses: cloudeteer/actions/get-terraform-version@main
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/module-ci-validate.yaml
+++ b/.github/workflows/module-ci-validate.yaml
@@ -10,8 +10,6 @@ jobs:
       - name: Get terraform version
         id: terraform_version
         uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
-        with:
-          file-path: versions.tf
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/module-ci-validate.yaml
+++ b/.github/workflows/module-ci-validate.yaml
@@ -3,11 +3,20 @@ on: workflow_call
 jobs:
   validate:
     runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:1.9
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Get terraform version
+        id: terraform_version
+        uses: cloudeteer/actions/get-terraform-version@42-use-a-specific-terraform-version-during-githubu-actions
+        with:
+          file-path: versions.tf
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.terraform_version.outputs.required_version }}
 
       - name: terraform init
         run: terraform init -backend=false


### PR DESCRIPTION
In most cases, the specific Terraform version used during module development or testing is not critical, as the Terraform CLI automatically adheres to the version constraints defined in the `terraform.tf` (or `versions.tf`) file. However, we specify the minimum required versions of both the Terraform CLI and the Terraform providers in each module, without actually testing them—these values are more of an educated guess.

This PR enhances the existing "Remote Test" workflow by adding two steps:

1. Detect the Terraform version.
2. Install the explicitly specified Terraform version.

Step 1 requires the `required_version` to be defined in the `terraform.tf` file for the remote test. We should update our style guide to recommend that the minimum recommended versions of Terraform and providers be specified in remote tests.

Additionally, this PR switches from using the Terraform container (version 1.9) to the new get-terraform-version action combined with the official HashiCorp setup-terraform action, ensuring more flexibility and alignment with the latest best practices.

Example:

If a module specifies the following versions in its `terraform.tf`:

```hcl
terraform {
  required_version = ">= 1.9"

  required_providers {
    azapi = {
      source  = "azure/azapi"
      version = ">= 1.14"
    }

    azurerm = {
      source  = "hashicorp/azurerm"
      version = ">= 4.1"
    }

    random = {
      source  = "hashicorp/random"
      version = ">= 3.1"
    }

    tls = {
      source  = "hashicorp/tls"
      version = ">= 4.0"
    }
  }
}
```

Our remote test should then use exactly these minimum versions, rather than following the version constraints and potentially using the latest Terraform version. For testing, we would define the following `tests/remote/terraform.tf` file:

```hcl
terraform {
  required_version = "1.9.0"

  required_providers {
    azapi = {
      source  = "azure/azapi"
      version = "1.14.0"
    }

    azurerm = {
      source  = "hashicorp/azurerm"
      version = "4.1.0"
    }

    random = {
      source  = "hashicorp/random"
      version = "3.1.0"
    }

    tls = {
      source  = "hashicorp/tls"
      version = "4.0.0"
    }
  }
}
```

This ensures that new features added to the module are fully compatible with the specified [version constraints](https://developer.hashicorp.com/terraform/language/expressions/version-constraints).