### PR TITLE
Allow auto merge by default

### DIFF
--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -41,6 +41,7 @@ resource "github_repository" "repository" {
   has_projects                = false
   has_wiki                    = false
   has_downloads               = false
+  allow_auto_merge            = true
   allow_merge_commit          = false
   allow_rebase_merge          = false
   allow_squash_merge          = true


### PR DESCRIPTION
We discussed some time ago that the "Allow auto merge" feature should be enabled by default for a GitHub repo. This PR does that.