### PR TITLE
Add module test deployment secrets

### DIFF
--- a/.github/workflows/module-repo-setup.yml
+++ b/.github/workflows/module-repo-setup.yml
@@ -66,8 +66,12 @@ jobs:
         if: ${{ inputs.unlock-lock-id }}
         run: tofu force-unlock "${{ inputs.unlock-lock-id }}" -force
       - name: tofu plan
+        env:
+          TF_VAR_ARM_CLIENT_ID: ${{ secrets.TERRAFORM_MODULE_TESTS_ARM_CLIENT_ID }}
+          TF_VAR_ARM_SUBSCRIPTION_ID: ${{ secrets.TERRAFORM_MODULE_TESTS_ARM_SUBSCRIPTION_ID }}
+          TF_VAR_ARM_TENANT_ID: ${{ secrets.TERRAFORM_MODULE_TESTS_ARM_TENANT_ID }}
         #language=bash
-        run: |-
+        run: |- # shell
           set +e
           tofu plan -out terraform.tfplan -detailed-exitcode
 

--- a/terraform/module-repo-setup.tf
+++ b/terraform/module-repo-setup.tf
@@ -44,4 +44,9 @@ module "github_repository" {
     [var.create_repo])
   ))
   repository_name = each.value
+  actions_secrets = {
+    ARM_CLIENT_ID: var.ARM_CLIENT_ID
+    ARM_SUBSCRIPTION_ID: var.ARM_SUBSCRIPTION_ID
+    ARM_TENANT_ID: var.ARM_TENANT_ID
+  }
 }

--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -3,6 +3,13 @@ variable "repository_name" {
   type        = string
 }
 
+variable "actions_secrets" {
+  description = "GitHub Actions evnrionment secrets to create."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
 terraform {
   required_providers {
     github = {
@@ -91,6 +98,16 @@ resource "github_repository_collaborators" "admins" {
     permission = "admin"
     username   = "neonwhiskers"
   }
+}
+
+# https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret
+resource "github_actions_secret" "this" {
+  for_each = nonsensitive(var.actions_secrets)
+
+  secret_name     = each.key
+  plaintext_value = sensitive(each.value)
+
+  repository = github_repository.repository.name
 }
 
 # https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,28 @@ variable "create_repo" {
   type        = string
   default     = ""
 }
+
+variable "actions_secrets" {
+  description = "GitHub Actions evnrionment secrets to create."
+  type        = map(string)
+  default     = {}
+}
+
+variable "ARM_CLIENT_ID" {
+  description = "The Client ID of the Azure managed identity utilized for authentication during test deployments."
+  type        = string
+  sensitive   = true
+}
+
+variable "ARM_SUBSCRIPTION_ID" {
+  description = "The Subscription ID of the Azure managed identity utilized for authentication during test deployments."
+  type        = string
+  sensitive   = true
+
+}
+
+variable "ARM_TENANT_ID" {
+  description = "The Tenant ID of the Azure managed identity utilized for authentication during test deployments."
+  sensitive   = true
+  type        = string
+}


### PR DESCRIPTION
This pull request adds the necessary secrets for Terraform test deployments in each module repository managed by GitHub Actions.

By configuring these secrets, we ensure that Terraform tests can run smoothly across all relevant repositories during the CI/CD pipeline.