### PR TITLE
Run CI job only when PR is not in draft mode

### DIFF
--- a/.github/workflows/module-ci-test.yaml
+++ b/.github/workflows/module-ci-test.yaml
@@ -31,6 +31,7 @@ jobs:
           terraform test -test-directory=tests/local
 
   test-remote:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Summary
This update modifies the CI workflow to ensure certain jobs only run when the pull request is **not** in draft mode.

### Changes
- Added a condition to skip specific jobs when the pull request is in draft mode (`github.event.pull_request.draft == false`).

### Benefits
- Reduces unnecessary CI runs for draft pull requests.
- Speeds up the feedback cycle during early draft development stages.