### PR TITLE
add project manage token to modules

### DIFF
--- a/.github/workflows/github-project.yaml
+++ b/.github/workflows/github-project.yaml
@@ -1,0 +1,11 @@
+name: 📇 Add Issues and PRs to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  github-project:
+    uses: ./.github/workflows/module-github-project.yaml

--- a/.github/workflows/module-github-project.yaml
+++ b/.github/workflows/module-github-project.yaml
@@ -1,0 +1,16 @@
+name: module-github-project
+
+on:
+  workflow_call:
+
+jobs:
+  project:
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: switch to main
+      #- uses: cloudeteer/actions/manage-github-project@main
+      - uses: cloudeteer/actions/manage-github-project@add-manage-github-project
+        with:
+          project-url: https://github.com/orgs/cloudeteer/projects/107
+          app-id: ${{ vars.ORGA_GITHUB_APP_ID_CDTGITHUBPROJECTMANAGEMENT }}
+          private-key: ${{ secrets.ORGA_GITHUB_APP_SECRET_CDTGITHUBPROJECTMANAGEMENT }}

--- a/.github/workflows/module-github.yaml
+++ b/.github/workflows/module-github.yaml
@@ -1,0 +1,9 @@
+name: module-manage-github
+
+on:
+  workflow_call:
+
+jobs:
+  project:
+    uses: ./.github/workflows/module-github-project.yaml
+    secrets: inherit


### PR DESCRIPTION
In order to add Issues and PRs automatically to the Terraform Module Development Project, a token is needed which has project write privileges.

So this token is rolled out to all modules. Each module needs to use the new workflow `cloudeteer/terraform-governance/.github/workflows/module-github.yaml`, that then does the above described.

New GitHub Actions workflows:

* [`.github/workflows/github-project.yaml`](diffhunk://#diff-faff12e8b23215866424a933c9718767f852a40b3d7db2607bba9c3f7614895dR1-R11): Added a workflow to automatically add issues and pull requests to the project when they are opened.
* [`.github/workflows/module-github-project.yaml`](diffhunk://#diff-35c752dc862a1dcf32960ac2970e7acd0a6ca07d8191d35e0254383d26894a3eR1-R16): Created a reusable workflow module to manage the GitHub project, including steps to use the `cloudeteer/actions/manage-github-project` action with specified project URL, app ID, and private key.
* [`.github/workflows/module-github.yaml`](diffhunk://#diff-b498c83377ccf3b9c84c1e34e0455b32f56f386cd72a6e34d714a7fe34827e61R1-R9): Added a workflow that calls the `module-github-project.yaml` workflow module, inheriting secrets for secure operation.