### PR TITLE
Fix Missing Warning Annotations in TFLint Configuration Comparison Workflow

### DIFF
--- a/.github/workflows/module-ci-lint.yaml
+++ b/.github/workflows/module-ci-lint.yaml
@@ -36,22 +36,28 @@ jobs:
       - name: Compare TFLint configuration files
         continue-on-error: true
         run: |
-          diff -u .terraform-governance/tflint.hcl .tflint.hcl
-          result=$?
-
-          if [ $result -eq 1 ]; then
-            echo "::warning::Your local .tflint.hcl file is different from the default one in the cloudeteer/terraform-governance repository. Please update your configuration file accordingly to make sure you have consistent documentation results."
-          elif [ $result -ge 1 ]; then
-            exit $result
+          # Compare tflint.hcl
+          if diff -u .terraform-governance/tflint.hcl .tflint.hcl > /dev/null; then
+            echo "No differences found in tflint.hcl"
+          else
+            result=$?
+            if [ $result -eq 1 ]; then
+              echo "::warning::Your local .tflint.hcl file is different from the default one in the cloudeteer/terraform-governance repository. Please update your configuration file accordingly to make sure you have consistent documentation results."
+            elif [ $result -gt 1 ]; then
+              echo "::error::An error occurred while comparing .tflint.hcl files."
+            fi
           fi
-
-          diff -u .terraform-governance/tflint.examples.hcl .tflint.examples.hcl
-          result=$?
-
-          if [ $result -eq 1 ]; then
-            echo "::warning::Your local .tflint.examples.hcl file is different from the default one in the cloudeteer/terraform-governance repository. Please update your configuration file accordingly to make sure you have consistent documentation results."
-          elif [ $result -ge 1 ]; then
-            exit $result
+          
+          # Compare tflint.examples.hcl
+          if diff -u .terraform-governance/tflint.examples.hcl .tflint.examples.hcl > /dev/null; then
+            echo "No differences found in tflint.examples.hcl"
+          else
+            result=$?
+            if [ $result -eq 1 ]; then
+              echo "::warning::Your local .tflint.examples.hcl file is different from the default one in the cloudeteer/terraform-governance repository. Please update your configuration file accordingly to make sure you have consistent documentation results."
+            elif [ $result -gt 1 ]; then
+              echo "::error::An error occurred while comparing .tflint.examples.hcl files."
+            fi
           fi
 
       - name: Init TFLint


### PR DESCRIPTION
Issue: https://github.com/cloudeteer/terraform-governance/issues/69


### **Exit Codes of `diff`:**
- **`0`**: The files are identical (no differences).
- **`1`**: The files are different.
- **`>1`**: An error occurred (e.g., file not found or permission issue).

---

### **Key Problem with `continue-on-error: true`:**
- `continue-on-error: true` allowed the step to proceed even if `diff` exited with `1` (differences) or `>1` (errors).
- However, it did not ensure that the `::warning::` messages were explicitly logged. The raw `diff` output overshadowed the annotations, causing warnings to not show up clearly in GitHub Actions logs. 

---

### **Solution:**
Handle `diff` results explicitly:
- Redirect its output and use `if` statements to manage `0`, `1`, and `>1` cases, ensuring annotations (`::warning::` or `::error::`) are logged correctly.

---

### **Testing:**
- Case 1: Identical Files: https://github.com/cloudeteer/playground-se/actions/runs/12233581277
  - Ensured the log contains "No differences found..." for both files.
- Case 2: Files with Differences: https://github.com/cloudeteer/playground-se/actions/runs/12233602635
  - Modified one of the files to simulate differences.
  - Confirm that the warning annotation (::warning::) appears in the logs.
- Case 3: File Missing/Error: https://github.com/cloudeteer/playground-se/actions/runs/12233621535
  - Delete one of the files.
  - Confirm that the error annotation (::error::) appears in the logs.
