### PR TITLE
Fix broken version calculation

### DIFF
--- a/.github/workflows/module-github-release.yaml
+++ b/.github/workflows/module-github-release.yaml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/module-github-release.yaml
+++ b/.github/workflows/module-github-release.yaml
@@ -12,6 +12,8 @@ jobs:
           fetch-depth: 0
 
       - name: Calculate new SemVer tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         id: tag
         run: | #shell
           git fetch --force --tags

--- a/.github/workflows/module-github-release.yaml
+++ b/.github/workflows/module-github-release.yaml
@@ -35,7 +35,7 @@ jobs:
               echo 'Found "feature" label, will do minor release if no breaking change in further labels found.'
               new_tag=$(echo "${prev_tag#v}" | awk -F. '{print "v"$1"."$2+1".0"}')
             fi
-          done < <(git log --pretty=format:%s "$prev_tag"..@ | grep -o -E '#\d+')
+          done < <(git log --pretty=format:%s "$prev_tag"..@ | grep -o -P '#\d+')
 
           if [ -z "$new_tag" ]; then
             echo 'No special labels found, will do patch release'


### PR DESCRIPTION
This pull request fixes the broken version calculation caused by differences in the behavior of the grep command. The issue arose because the grep command was tested on a macOS machine (using BSD grep), which behaves differently from GNU grep used on Linux machines (e.g., GitHub Runner ubuntu-latest).

The fix ensures that the version calculation works reliably on Linux. macOS compatibility is not addressed and is ignored in this fix.

---
These screenshots show that the version calculation works as expected

#### Minor Release (`feature` label)
![image](https://github.com/user-attachments/assets/5f0d47b4-210a-4047-af3e-ee85e5a417f3)

#### Major Release (`breaking-change` label)
![image](https://github.com/user-attachments/assets/78f85645-1d4f-4573-bde2-69d4bd458291)

