### PR TITLE
OE-593: add precommit run to ci

### DIFF
--- a/.github/workflows/module-ci-precommit.yaml
+++ b/.github/workflows/module-ci-precommit.yaml
@@ -1,0 +1,54 @@
+name: module-ci-precommit
+on: workflow_call
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        name: Checkout source code
+
+      - name: Get terraform version
+        id: terraform_version
+        uses: cloudeteer/actions/get-terraform-version@main
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ steps.terraform_version.outputs.required_version }}
+
+      - name: Show Terraform version
+        run: terraform version
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@90f302c255ef959cbfb4bd10581afecdb7ece3e6 # v4.1.1
+
+      - name: Show TFLint version
+        run: tflint --version
+
+      - name: Setup Terraform docs
+        run: go install github.com/terraform-docs/terraform-docs@v0.20.0
+
+      - name: Add Go bin to PATH
+        run: echo "$HOME/go/bin" >> $GITHUB_PATH
+
+      - name: Show Terraform docs version
+        run: terraform-docs --version
+
+      - name: Setup tfsort
+        run: go install github.com/AlexNabokikh/tfsort@latest
+
+      - name: Show tfsort version
+        run: tfsort --version
+
+      - name: Setup Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.65.0
+
+      - name: Show Trivy version
+        run: trivy --version
+
+      - name: Setup pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files

--- a/.github/workflows/module-ci.yaml
+++ b/.github/workflows/module-ci.yaml
@@ -14,6 +14,9 @@ jobs:
   lint:
     uses: ./.github/workflows/module-ci-lint.yaml
 
+  precommit:
+    uses: ./.github/workflows/module-ci-precommit.yaml
+
   documentation:
     uses: ./.github/workflows/module-ci-documentation.yaml
 
@@ -29,5 +32,5 @@ jobs:
 
   issue:
     if: github.event_name == 'schedule' && failure()
-    needs: [validate, lint, documentation, code-analysis, test]
+    needs: [validate, lint, precommit, documentation, code-analysis, test]
     uses: ./.github/workflows/module-ci-issue.yaml


### PR DESCRIPTION
This pull request introduces a new pre-commit workflow for module CI and integrates it into the main module CI workflow. The changes automate the setup and execution of several tools (Terraform, TFLint, terraform-docs, tfsort, Trivy, and pre-commit) to ensure code quality and security as part of the CI process.

**CI Workflow Enhancements:**

* Added a new workflow file, `.github/workflows/module-ci-precommit.yaml`, which sets up and runs pre-commit checks, including installing and verifying versions for Terraform, TFLint, terraform-docs, tfsort, and Trivy, as well as running pre-commit hooks.
* Updated `.github/workflows/module-ci.yaml` to include the new `precommit` job, integrating the pre-commit workflow into the main module CI pipeline.