### PR TITLE
Fix PR workflow triggers for label validation

### DIFF
--- a/docs/Module - Workflow Github.md
+++ b/docs/Module - Workflow Github.md
@@ -20,6 +20,8 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
+      - synchronize
       - labeled
       - unlabeled
 


### PR DESCRIPTION
## Summary

- Fix missing pull_request trigger types that prevented label validation from running when commits were pushed to existing PRs or when PRs were reopened

## Details

The module workflow documentation recommended trigger configuration was missing `reopened` and `synchronize` activity types. This caused the label validation workflow to not run when:

- New commits were pushed to existing PRs (synchronize)
- Closed PRs were reopened (reopened)

This could result in PRs being merged without required labels after new commits were pushed.